### PR TITLE
Update odsw.py

### DIFF
--- a/pyexcel_ods3/odsw.py
+++ b/pyexcel_ods3/odsw.py
@@ -45,8 +45,12 @@ class ODSSheetWriter(ISheetWriter):
                 cell = "PT%02dH%02dM%02dS" % (hours, minutes, seconds)
                 value_type = "time"
             if value_type == 'datetime':
-                cell = "%04d-%02d-%02dT%02d:%02d:%02d" % (cell.year, cell.month, cell.day,
-                                                          cell.hour, cell.minute, cell.second)
+                cell = "%04d-%02d-%02dT%02d:%02d:%02d" % (cell.year,
+                                                          cell.month,
+                                                          cell.day,
+                                                          cell.hour,
+                                                          cell.minute,
+                                                          cell.second)
                 value_type = "date"
             elif value_type == "float":
                 if cell > MAX_INTEGER:

--- a/pyexcel_ods3/odsw.py
+++ b/pyexcel_ods3/odsw.py
@@ -44,6 +44,10 @@ class ODSSheetWriter(ISheetWriter):
                 seconds = cell.seconds % 60
                 cell = "PT%02dH%02dM%02dS" % (hours, minutes, seconds)
                 value_type = "time"
+            if value_type == 'datetime':
+                cell = "%04d-%02d-%02dT%02d:%02d:%02d" % (cell.year, cell.month, cell.day,
+                                                          cell.hour, cell.minute, cell.second)
+                value_type = "date"
             elif value_type == "float":
                 if cell > MAX_INTEGER:
                     raise IntegerAccuracyLossError("%s is too big" % cell)


### PR DESCRIPTION
Add `datetime.datetime` support to `pyexcel_ods3.odsw.ODSSheetWriter.write_row(array)` method.
To be usable, this patch requires first that a pull request is accepted by pyexcel_io maintainers (`datetime.datetime: "datetime"` key:value pair must be added to `ODS_WRITE_FORMAT_COVERSION` dictionary.. 
Thank you


With your PR, here is a check list:

- [ ] Has test cases written?
- [ ] Has all code lines tested?
- [ ] Has `make format` been run?
- [ ] Please update CHANGELOG.yml(not CHANGELOG.rst)
- [ ] Has fair amount of documentation if your change is complex
- [ ] Agree on NEW BSD License for your contribution
