### PR TITLE
Attach sheet to book before writing cells to avoid quadratic namespac…

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -2,6 +2,14 @@ name: pyexcel-ods3
 organisation: pyexcel
 releases:
 - changes:
+  - action: updated
+    details:
+    - attach the sheet to the book before writing cells, so that saving a sheet
+      is linear instead of quadratic in the number of cells. Saving 100000 rows
+      x 4 columns drops from ~228s to ~5s.
+  date: unreleased
+  version: 0.6.3
+- changes:
   - action: added
     details:
     - '`#36`: fixing get_data for a currency cell with no currency defined'

--- a/pyexcel_ods3/odsw.py
+++ b/pyexcel_ods3/odsw.py
@@ -25,6 +25,11 @@ class ODSSheetWriter(ISheetWriter):
     def __init__(self, ods_book, ods_sheet, sheet_name, **keywords):
         self.ods_book = ods_book
         self.ods_sheet = ezodf.Sheet(sheet_name)
+        # Attach the sheet to the book while it is still empty. Appending
+        # a fully populated sheet would make lxml reconcile the namespace
+        # declarations of every cell at once, which scales quadratically
+        # with the number of cells.
+        self.ods_book.sheets += self.ods_sheet
         self.current_row = 0
 
     def _set_size(self, size):
@@ -81,7 +86,6 @@ class ODSSheetWriter(ISheetWriter):
         This call writes file
 
         """
-        self.ods_book.sheets += self.ods_sheet
 
 
 class ODSWriter(IWriter):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from base import PyexcelWriterBase, PyexcelHatWriterBase
 from pyexcel_ods3 import get_data
@@ -45,6 +46,37 @@ class TestodsHatWriter(PyexcelHatWriterBase):
     def teardown_method(self):
         if os.path.exists(self.testfile):
             os.unlink(self.testfile)
+
+
+def test_writing_100k_rows_stays_linear():
+    # Regression test for the quadratic append() cost: writing a sheet
+    # detached from the book and only attaching it on close() used to take
+    # ~228s for 100000 rows, because attaching the fully populated sheet
+    # made lxml reconcile the namespace declarations of every cell in one
+    # pass. A fix keeping this linear should stay well under 10s even on
+    # slow CI machines.
+    test_file = "linear.ods"
+    rows = [
+        [i, i * 7, "verb", f"row {i}, a moderately long description string"]
+        for i in range(100000)
+    ]
+    writer = Writer(test_file, "ods")
+    t0 = time.perf_counter()
+    writer.write({"Sheet1": rows})
+    writer.close()
+    elapsed = time.perf_counter() - t0
+
+    content = get_data(test_file)
+    written_rows = list(content["Sheet1"])
+    assert written_rows[0] == rows[0]
+    assert written_rows[-1] == rows[-1]
+
+    os.unlink(test_file)
+
+    assert elapsed < 10, (
+        f"writing 100000 rows took {elapsed:.1f}s; "
+        "this used to take ~228s due to quadratic namespace reconciliation"
+    )
 
 
 def test_pr_28():


### PR DESCRIPTION
With your PR, here is a check list:

- [x] Has test cases written? — `test_writing_100k_rows_stays_linear` in `tests/test_writer.py`: writes 100000 rows and asserts this stays under 10s and the content round-trips correctly. Fails at ~252s against the unfixed code.
- [x] Has all code lines tested? — full suite passes: 50 passed, 1 skipped
- [x] Has `make format` been run? — yes (isort + black, no further changes)
- [x] Please update CHANGELOG.yml(not CHANGELOG.rst) — added an `unreleased` 0.6.3 entry to `changelog.yml`
- [x] Has fair amount of documentation if your change is complex — rationale documented in a code comment, this description, and the commit message
- [x] Agree on NEW BSD License for your contribution

## Problem

`save_data()` slows down non-linearly with the number of rows. Writing a single sheet of 100,000 rows × 4 columns (int, int, short str, long str) takes ~228 s on 0.6.1 / current master:

| rows | time | per row |
|---:|---:|---:|
| 100 | 0.007 s | 66 µs |
| 1,000 | 0.062 s | 62 µs |
| 10,000 | 1.2 s | 122 µs |
| 100,000 | **228 s** | 2,279 µs |

10× the data → ~187× the time, i.e. O(n²).

## Root cause

`ODSSheetWriter.__init__` creates a **detached** `ezodf.Sheet`, all cells are written into it, and only `close()` appends the fully populated sheet to the book (`self.ods_book.sheets += self.ods_sheet`). cProfile on a 30,000-row write shows 6.4 s of 9.9 s spent in that single `append()` (`ezodf/pagecontainer.py`): when the subtree is moved into the document, lxml reconciles the namespace declarations of every cell element in one pass, which is quadratic in the number of cells.

## Fix

Attach the still-empty sheet to the book in `__init__` and make `close()` a no-op. Every cell append is then a small in-document operation, so writing time becomes linear:

| rows | before | after |
|---:|---:|---:|
| 10,000 | 1.2 s | 0.48 s |
| 100,000 | 228 s | **4.9 s** (constant 49 µs/row) |

~46× faster at 100,000 rows.

## Verification

- Output files are content-equivalent: reading the file back with `get_data()` before and after the patch yields identical data.
- Test suite passes: 50 passed, 1 skipped (`pytest tests/`).
- Added `test_writing_100k_rows_stays_linear`, which fails against the unfixed code (~252s, over the 10s bound) and passes against the fix (~5s).
- Manually confirmed red/green: ran this test against the pre-fix odsw.py (red, ~252s AssertionError) and against the fix (green, ~5s pass).

## How to reproduce

Run the script below against pyexcel-ods3 0.6.1 (or current master), then against this branch. Numbers above were measured with Python 3.12 and pyexcel-ods3==0.6.1.

<details>
<summary><code>bench_save_data.py</code></summary>

```python
"""Benchmark pyexcel_ods3.save_data() scaling with row count."""
import sys
import time
import tempfile
from pathlib import Path
from collections import OrderedDict

from pyexcel_ods3 import save_data


def make_data(n):
    rows = [["id", "ref", "kind", "description"]]
    for i in range(n):
        rows.append(
            [i, i * 7, "verb", f"This is row {i}, a moderately long description string for realism."]
        )
    return OrderedDict(sheet=rows)


def bench(n):
    data = make_data(n)
    with tempfile.TemporaryDirectory() as d:
        path = Path(d) / "test.ods"
        t0 = time.perf_counter()
        save_data(str(path), data)
        return time.perf_counter() - t0


if __name__ == "__main__":
    sizes = [int(a) for a in sys.argv[1:]] or [1, 10, 100, 1000, 10000, 100000]
    print(f"{'rows':>8} {'seconds':>12} {'sec/row':>12}")
    for n in sizes:
        el = bench(n)
        print(f"{n:>8} {el:>12.4f} {el / n:>12.6f}", flush=True)
```

</details>

```console
$ pip install pyexcel-ods3==0.6.1
$ python bench_save_data.py          # heads up: the 100000-row case takes ~4 min before the fix
$ pip install git+https://github.com/<user>/pyexcel-ods3@fix-quadratic-sheet-append
$ python bench_save_data.py
```

Pass row counts as arguments to try other sizes, e.g. `python bench_save_data.py 1000 10000`. Watch the `sec/row` column: before the fix it grows with n (quadratic total time); after the fix it stays flat (~49 µs/row on my machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code), and manually reviewed and verified by the author before submission.
